### PR TITLE
Rotation handling

### DIFF
--- a/src/common/bicop_archimedean.cpp
+++ b/src/common/bicop_archimedean.cpp
@@ -18,8 +18,6 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "include/bicop_archimedean.hpp"
-#include <iostream>
-
 
 // PDF
 VecXd ArchimedeanBicop::pdf_default(const MatXd& u)

--- a/src/common/bicop_archimedean.cpp
+++ b/src/common/bicop_archimedean.cpp
@@ -18,152 +18,45 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "include/bicop_archimedean.hpp"
+#include <iostream>
 
 
 // PDF
-VecXd ArchimedeanBicop::pdf(const MatXd& u)
+VecXd ArchimedeanBicop::pdf_default(const MatXd& u)
 {
     VecXd f = VecXd::Ones(u.rows());
-    int rotation = get_rotation();
-
-    if (rotation == 0) {
-        VecXd v = generator(u.col(0)) + generator(u.col(1));
-        f = generator_derivative(u.col(0)).cwiseProduct(generator_derivative(u.col(1)));
-        VecXd numerator = generator_derivative2(generator_inv(v));
-        VecXd denominator = generator_derivative(generator_inv(v)).array().pow(3.0);
-        f = (-1)*f.cwiseProduct(numerator);
-        f = f.cwiseQuotient(denominator);
-    } else {
-        MatXd v = u;
-        set_rotation(0);
-        VecXd parameters = get_parameters();
-        if (rotation == 180) {
-            v = MatXd::Ones(u.rows(), u.cols()) - v;
-        } else {
-            set_parameters((-1) * parameters);
-            if (rotation == 90) {
-                v.col(0) = VecXd::Ones(u.rows()) - v.col(0);
-            } else {
-                v.col(1) = VecXd::Ones(u.rows()) - v.col(1);
-            }
-        }
-
-        f = pdf(v);
-        set_rotation(rotation);
-        if (rotation == 90 || rotation == 270) {
-            set_parameters(parameters);
-        }
-    }
+    VecXd v = generator(u.col(0)) + generator(u.col(1));
+    f = generator_derivative(u.col(0)).cwiseProduct(generator_derivative(u.col(1)));
+    VecXd numerator = generator_derivative2(generator_inv(v));
+    VecXd denominator = generator_derivative(generator_inv(v)).array().pow(3.0);
+    f = (-1)*f.cwiseProduct(numerator);
+    f = f.cwiseQuotient(denominator);
 
     return f;
 }
 
-VecXd ArchimedeanBicop::hfunc1(const MatXd& u)
+VecXd ArchimedeanBicop::hfunc1_default(const MatXd& u)
 {
-    VecXd h = VecXd::Ones(u.rows());
-    int rotation = get_rotation();
+    VecXd h(u.rows());
+    VecXd v(u.rows());
 
-    if (rotation == 0) {
-        VecXd v = VecXd::Ones(u.rows());
-        v = generator(u.col(0)) + generator(u.col(1));
-        h = generator_derivative(u.col(0)).cwiseQuotient(generator_derivative(generator_inv(v)));
-    } else {
-        MatXd v = u;
-        set_rotation(0);
-        VecXd parameters = get_parameters();
-        if (rotation == 180) {
-            v = MatXd::Ones(u.rows(), u.cols()) - v;
-        } else {
-            set_parameters((-1)*parameters);
-            if (rotation == 90) {
-                v.col(0) = VecXd::Ones(u.rows()) - v.col(0);
-            } else {
-                v.col(1) = VecXd::Ones(u.rows()) - v.col(1);
-            }
-        }
-
-        h = hfunc1(v);
-        set_rotation(rotation);
-        set_parameters(parameters);
-        if (rotation == 180 || rotation == 270) {
-            h = VecXd::Ones(u.rows()) - h;
-        }
-    }
+    v = generator(u.col(0)) + generator(u.col(1));
+    h = generator_derivative(u.col(0)).cwiseQuotient(generator_derivative(generator_inv(v)));
 
     return h;
 }
 
-VecXd ArchimedeanBicop::hfunc2(const MatXd& u)
+VecXd ArchimedeanBicop::hfunc2_default(const MatXd& u)
 {
-    VecXd h = VecXd::Ones(u.rows());
-    MatXd v = u;
-    v.col(0).swap(v.col(1));
-    int rotation = get_rotation();
-    if (rotation == 90) {
-        set_rotation(270);
-        h = hfunc1(v);
-        set_rotation(90);
-    } else if (rotation == 270) {
-        set_rotation(90);
-        h = hfunc1(v);
-        set_rotation(270);
-    } else {
-        h = hfunc1(v);
-    }
-
-    return h;
+    return hfunc1_default(swap_cols(u));
 }
 
-VecXd ArchimedeanBicop::hinv1(const MatXd& u)
+VecXd ArchimedeanBicop::hinv1_default(const MatXd& u)
 {
-    VecXd h = VecXd::Ones(u.rows());
-    int rotation = get_rotation();
-
-    if (rotation == 0) {
-        h = hinv(u);
-    } else {
-
-        MatXd v = u;
-        set_rotation(0);
-        VecXd parameters = get_parameters();
-        if (rotation == 180) {
-            v = MatXd::Ones(u.rows(), u.cols()) - v;
-        } else {
-            set_parameters((-1) * parameters);
-            if (rotation == 90) {
-                v.col(0) = VecXd::Ones(u.rows()) - v.col(0);
-            } else {
-                v.col(1) = VecXd::Ones(u.rows()) - v.col(1);
-            }
-        }
-
-        h = hinv1(v);
-        set_rotation(rotation);
-        set_parameters(parameters);
-        if (rotation == 180 || rotation == 270) {
-            h = VecXd::Ones(u.rows()) - h;
-        }
-    }
-    return h;
+    return hinv(u);
 }
 
-VecXd ArchimedeanBicop::hinv2(const MatXd& u)
+VecXd ArchimedeanBicop::hinv2_default(const MatXd& u)
 {
-    VecXd h = VecXd::Ones(u.rows());
-    MatXd v = u;
-    v.col(0).swap(v.col(1));
-    int rotation = get_rotation();
-    if (rotation == 90) {
-        set_rotation(270);
-        h = hinv1(v);
-        set_rotation(90);
-    } else if (rotation == 270) {
-        set_rotation(90);
-        h = hinv1(v);
-        set_rotation(270);
-    } else {
-        h = hinv1(v);
-    }
-
-    return h;
+    return hinv(swap_cols(u));
 }

--- a/src/common/bicop_class.cpp
+++ b/src/common/bicop_class.cpp
@@ -20,6 +20,174 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 #include <exception>
 #include "include/bicop_class.hpp"
 
+VecXd Bicop::pdf(const MatXd& u)
+{
+    return pdf_default(rotate_u(u));
+}
+
+
+VecXd Bicop::hfunc1(const MatXd& u)
+{
+    switch (rotation_) {
+        case 0:
+            return hfunc1_default(u);
+
+        case 90:
+            return hfunc2_default(rotate_u(u));
+
+        case 180:
+            return 1.0 - hfunc1_default(rotate_u(u)).array();
+
+        case 270:
+            return 1.0 - hfunc2_default(rotate_u(u)).array();
+
+        default:
+            throw std::runtime_error(std::string(
+                "rotation can only take values in {0, 90, 180, 270}"
+            ));
+    }
+}
+
+VecXd Bicop::hfunc2(const MatXd& u)
+{
+    switch (rotation_) {
+        case 0:
+            return hfunc2_default(u);
+
+        case 90:
+            return 1.0 - hfunc1_default(rotate_u(u)).array();
+
+        case 180:
+            return 1.0 - hfunc2_default(rotate_u(u)).array();
+
+        case 270:
+            return hfunc1_default(rotate_u(u));
+
+        default:
+            throw std::runtime_error(std::string(
+                "rotation can only take values in {0, 90, 180, 270}"
+            ));
+    }
+}
+
+VecXd Bicop::hinv1(const MatXd& u)
+{
+    switch (rotation_) {
+        case 0:
+            return hinv1_default(u);
+
+        case 90:
+            return hinv2_default(rotate_u(u));
+
+        case 180:
+            return 1.0 - hinv1_default(rotate_u(u)).array();
+
+        case 270:
+            return 1.0 - hinv2_default(rotate_u(u)).array();
+
+        default:
+            throw std::runtime_error(std::string(
+                "rotation only takes value in {0, 90, 180, 270}"
+            ));
+    }
+}
+
+VecXd Bicop::hinv2(const MatXd& u)
+{
+    switch (rotation_) {
+        case 0:
+            return hinv2_default(u);
+
+        case 90:
+            return 1.0 - hinv1_default(rotate_u(u)).array();
+
+        case 180:
+            return 1.0 - hinv2_default(rotate_u(u)).array();
+
+        case 270:
+            return hinv1_default(rotate_u(u));
+
+        default:
+            throw std::runtime_error(std::string(
+                "rotation only takes value in {0, 90, 180, 270}"
+            ));
+    }
+}
+
+MatXd Bicop::simulate(const int& n)
+{
+    std::default_random_engine generator(time(0));
+    std::uniform_real_distribution<double> distribution(0.0, 1.0);
+
+    MatXd U = MatXd::Zero(n, 2);
+    for (int i = 0; i < n; ++i) {
+        U(i, 0) = distribution(generator);
+        U(i, 1) = distribution(generator);
+    }
+    U.col(1) = hinv1(U);
+
+    return U;
+}
+
+double Bicop::loglik(const MatXd& u)
+{
+    VecXd ll = this->pdf(u);
+    ll = ll.array().log();
+    return ll.sum();
+}
+
+double Bicop::aic(const MatXd& u)
+{
+    return -2 * this->loglik(u) + 2 * calculate_npars();
+}
+
+double Bicop::bic(const MatXd& u)
+{
+    return -2 * this->loglik(u) + 2 * log(this->calculate_npars());
+}
+
+// TODO: generic fall-back that calculates Kendall's tau based on the pdf:
+// tau = int_0^1 int_0^1 C(u, v) c(u, v) du dv
+//     = int_0^1 int_0^1 (int_0^u int_0^v c(s, t) ds dt) c(u, v) du dv
+double Bicop::calculate_tau()
+{
+    return 999.0;
+}
+
+MatXd Bicop::rotate_u(const MatXd& u)
+{
+    MatXd u_rotated(u.rows(), u.cols());
+    // counter-clockwise rotations
+    switch (rotation_) {
+        case 0:
+            u_rotated = u;
+            break;
+
+        case 90:
+            u_rotated.col(0) = u.col(1);
+            u_rotated.col(1) = 1.0 - u.col(0).array();
+            break;
+
+        case 180:
+            u_rotated.col(0) = 1.0 - u.col(0).array();
+            u_rotated.col(1) = 1.0 - u.col(1).array();
+            break;
+
+        case 270:
+            u_rotated.col(0) = 1.0 - u.col(1).array();
+            u_rotated.col(1) = u.col(0);
+            break;
+    }
+
+    return u_rotated;
+}
+
+MatXd Bicop::swap_cols(const MatXd& u)
+{
+    MatXd u_swapped = u;
+    u_swapped.col(0).swap(u_swapped.col(1));
+    return u_swapped;
+}
 
 
 VecXd Bicop::hinv1_num(const MatXd &u)
@@ -74,8 +242,6 @@ VecXd Bicop::hinv1_num(const MatXd &u)
 
     return v.col(1);
 }
-
-
 VecXd Bicop::hinv2_num(const MatXd& u)
 {
     MatXd v = u;
@@ -127,44 +293,4 @@ VecXd Bicop::hinv2_num(const MatXd& u)
     }
 
     return v.col(0);
-}
-
-MatXd Bicop::simulate(const int& n)
-{
-    std::default_random_engine generator(time(0));
-    std::uniform_real_distribution<double> distribution(0.0, 1.0);
-
-    MatXd U = MatXd::Zero(n, 2);
-    for (int i = 0; i < n; ++i) {
-        U(i, 0) = distribution(generator);
-        U(i, 1) = distribution(generator);
-    }
-    U.col(1) = hinv1(U);
-
-    return U;
-}
-
-double Bicop::loglik(const MatXd& u)
-{
-    VecXd ll = this->pdf(u);
-    ll = ll.array().log();
-    return ll.sum();
-}
-
-double Bicop::aic(const MatXd& u)
-{
-    return -2 * this->loglik(u) + 2 * calculate_npars();
-}
-
-double Bicop::bic(const MatXd& u)
-{
-    return -2 * this->loglik(u) + 2 * log(this->calculate_npars());
-}
-
-// TODO: generic fall-back that calculates Kendall's tau based on the pdf:
-// tau = int_0^1 int_0^1 C(u, v) c(u, v) du dv
-//     = int_0^1 int_0^1 (int_0^u int_0^v c(s, t) ds dt) c(u, v) du dv
-double Bicop::calculate_tau()
-{
-    return 999.0;
 }

--- a/src/common/bicop_class.cpp
+++ b/src/common/bicop_class.cpp
@@ -20,6 +20,8 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 #include <exception>
 #include "include/bicop_class.hpp"
 
+
+
 VecXd Bicop::hinv1_num(const MatXd &u)
 {
     MatXd v = u;
@@ -142,23 +144,21 @@ MatXd Bicop::simulate(const int& n)
     return U;
 }
 
-double Bicop::loglik(MatXd& u)
+double Bicop::loglik(const MatXd& u)
 {
     VecXd ll = this->pdf(u);
     ll = ll.array().log();
     return ll.sum();
 }
 
-double Bicop::aic(MatXd& u)
+double Bicop::aic(const MatXd& u)
 {
-    double out = -2 * this->loglik(u) + 2 * calculate_npars();
-    return out;
+    return -2 * this->loglik(u) + 2 * calculate_npars();
 }
 
-double Bicop::bic(MatXd& u)
+double Bicop::bic(const MatXd& u)
 {
-    double out = -2 * this->loglik(u) + 2 * log(this->calculate_npars());
-    return out;
+    return -2 * this->loglik(u) + 2 * log(this->calculate_npars());
 }
 
 // TODO: generic fall-back that calculates Kendall's tau based on the pdf:

--- a/src/common/bicop_elliptical.cpp
+++ b/src/common/bicop_elliptical.cpp
@@ -20,20 +20,14 @@
 #include "include/bicop_elliptical.hpp"
 
 
-VecXd EllipticalBicop::hfunc2(const MatXd& u)
+VecXd EllipticalBicop::hfunc2_default(const MatXd& u)
 {
-    MatXd v = u;
-    v.col(0).swap(v.col(1));
-    VecXd h = hfunc1(v);
-    return h;
+    return hfunc1_default(swap_cols(u));
 }
 
-VecXd EllipticalBicop::hinv2(const MatXd& u)
+VecXd EllipticalBicop::hinv2_default(const MatXd& u)
 {
-    MatXd v = u;
-    v.col(0).swap(v.col(1));
-    VecXd h = hinv1(v);
-    return h;
+    return hinv1_default(swap_cols(u));
 }
 
 double EllipticalBicop::parameters_to_tau(const VecXd& parameters)

--- a/src/common/bicop_gauss.cpp
+++ b/src/common/bicop_gauss.cpp
@@ -51,19 +51,16 @@ GaussBicop::GaussBicop(const VecXd& parameters, const int& rotation)
 }
 
 // PDF
-VecXd GaussBicop::pdf(const MatXd& u)
+VecXd GaussBicop::pdf_default(const MatXd& u)
 {
-    int j;
-    double u1, u2, t1, t2, tmp;
+    double t1, t2, tmp;
     double rho = double(this->parameters_(0));
     VecXd f = VecXd::Zero(u.rows());
     //boost::math::normal dist(0,1);
 
-    for (j = 0; j < u.rows(); ++j) {
-        u1 = u(j, 0);
-        u2 = u(j, 1);
-        t1 = gsl_cdf_ugaussian_Pinv(u1);
-        t2 = gsl_cdf_ugaussian_Pinv(u2);
+    for (int j = 0; j < u.rows(); ++j) {
+        t1 = gsl_cdf_ugaussian_Pinv(u(j, 0));
+        t2 = gsl_cdf_ugaussian_Pinv(u(j, 1));
         tmp = gsl_ran_bivariate_gaussian_pdf(t1, t2, 1.0, 1.0, rho);
         tmp /= gsl_ran_ugaussian_pdf(t1) * gsl_ran_ugaussian_pdf(t2);
         f(j) = tmp;
@@ -77,7 +74,7 @@ VecXd GaussBicop::pdf(const MatXd& u)
 
 
 // Normal h-function
-VecXd GaussBicop::hfunc1(const MatXd& u)
+VecXd GaussBicop::hfunc1_default(const MatXd& u)
 {
     double rho = double(this->parameters_(0));
     int j;
@@ -111,7 +108,7 @@ VecXd GaussBicop::hfunc1(const MatXd& u)
 }
 
 
-VecXd GaussBicop::hinv1(const MatXd& u)
+VecXd GaussBicop::hinv1_default(const MatXd& u)
 {
     double rho = double(this->parameters_(0));
     VecXd hinv = VecXd::Zero(u.rows());

--- a/src/common/bicop_indep.cpp
+++ b/src/common/bicop_indep.cpp
@@ -48,22 +48,30 @@ IndepBicop::IndepBicop(const VecXd& parameters, const int& rotation)
 }
 
 // PDF
-VecXd IndepBicop::pdf(const MatXd& u)
+VecXd IndepBicop::pdf_default(const MatXd& u)
 {
     return VecXd::Ones(u.rows());
 }
 
 // hfunctions: the conditioning variable is put second
-VecXd IndepBicop::hfunc1(const MatXd& u)
+VecXd IndepBicop::hfunc1_default(const MatXd& u)
 {
-    VecXd v = u.col(1);
-    return v;
+    return u.col(1);
 }
 
-VecXd IndepBicop::hfunc2(const MatXd& u)
+VecXd IndepBicop::hfunc2_default(const MatXd& u)
 {
-    VecXd v = u.col(0);
-    return v;
+    return u.col(0);
+}
+
+VecXd IndepBicop::hinv1_default(const MatXd& u)
+{
+    return u.col(1);
+}
+
+VecXd IndepBicop::hinv2_default(const MatXd& u)
+{
+    return u.col(0);
 }
 
 VecXd IndepBicop::tau_to_parameters(const double __attribute__((unused))& tau)
@@ -74,14 +82,4 @@ VecXd IndepBicop::tau_to_parameters(const double __attribute__((unused))& tau)
 double IndepBicop::parameters_to_tau(const VecXd __attribute__((unused))& parameters)
 {
     return 0.0;
-}
-
-VecXd IndepBicop::hinv1(const MatXd& u)
-{
-    return u.col(1);
-}
-
-VecXd IndepBicop::hinv2(const MatXd& u)
-{
-    return u.col(0);
 }

--- a/src/common/bicop_joe.cpp
+++ b/src/common/bicop_joe.cpp
@@ -161,7 +161,7 @@ double JoeBicop::parameters_to_tau(const VecXd& parameters)
     tau = 1 + 2 * tau / (2 - par);
     if ((rotation_ == 90) | (rotation_ == 270))
         tau *= -1;
-    
+
     return tau;
 }
 
@@ -212,7 +212,8 @@ double qcondjoe(double* q, double* u, double* de)
         if(isnan(pdf) || isnan(c21) ) { diff/=-2.; }  // added for de>=30
         else diff=(c21-*q)/pdf;
         v-=diff;
-        while(v<=0 || v>=1 || fabs(diff)>0.25 ) { diff/=2.; v+=diff; }
+        int iter2 = 0;
+        while((v<=0 || v>=1 || fabs(diff)>0.25) & (iter2 <20)) {++iter2; diff/=2.; v+=diff; }
     }
     return(v);
 }

--- a/src/common/bicop_student.cpp
+++ b/src/common/bicop_student.cpp
@@ -58,19 +58,17 @@ StudentBicop::StudentBicop(const VecXd& parameters, const int& rotation)
 }
 
 // PDF
-VecXd StudentBicop::pdf(const MatXd& u)
+VecXd StudentBicop::pdf_default(const MatXd& u)
 {
     int j;
-    double u1, u2, t1, t2;
+    double t1, t2;
     double rho = double(this->parameters_(0));
     double nu = double(this->parameters_(1));
     VecXd f = VecXd::Zero(u.rows());
 
     for (j = 0; j < u.rows(); ++j) {
-        u1 = u(j, 0);
-        u2 = u(j, 1);
-        t1 = gsl_cdf_tdist_Pinv(u1, nu);
-        t2 = gsl_cdf_tdist_Pinv(u2, nu);
+        t1 = gsl_cdf_tdist_Pinv(u(j, 0), nu);
+        t2 = gsl_cdf_tdist_Pinv(u(j, 1), nu);
         f(j) = StableGammaDivision((nu + 2.0) / 2.0, nu / 2.0) /
         (nu * M_PI * sqrt(1.0 - pow(rho, 2.0)) *
         gsl_ran_tdist_pdf(t1, nu) *
@@ -85,7 +83,7 @@ return f;
 }
 
 // Student h-function
-VecXd StudentBicop::hfunc1(const MatXd& u)
+VecXd StudentBicop::hfunc1_default(const MatXd& u)
 {
     double rho = double(this->parameters_(0));
     double nu = double(this->parameters_(1));
@@ -112,7 +110,7 @@ VecXd StudentBicop::hfunc1(const MatXd& u)
 }
 
 
-VecXd StudentBicop::hinv1(const MatXd& u)
+VecXd StudentBicop::hinv1_default(const MatXd& u)
 {
     double rho = double(this->parameters_(0));
     double nu = double(this->parameters_(1));

--- a/src/common/include/bicop_archimedean.hpp
+++ b/src/common/include/bicop_archimedean.hpp
@@ -26,11 +26,13 @@ class ArchimedeanBicop : public ParBicop {
 
 public:
     // PDF
-    VecXd pdf(const MatXd& u);
+    VecXd pdf_default(const MatXd& u);
 
     // hfunctions: the conditioning variable is put second
-    VecXd hfunc1(const MatXd& u);
-    VecXd hfunc2(const MatXd& u);
+    VecXd hfunc1_default(const MatXd& u);
+    VecXd hfunc2_default(const MatXd& u);
+    VecXd hinv1_default(const MatXd& u);
+    VecXd hinv2_default(const MatXd& u);
 
     // generator, its inverse and derivatives for the archimedean copula
     virtual VecXd generator(const VecXd& u) = 0;
@@ -39,8 +41,6 @@ public:
     virtual VecXd generator_derivative2(const VecXd& u) = 0;
 
     virtual VecXd hinv(const MatXd& u) = 0;
-    VecXd hinv1(const MatXd& u);
-    VecXd hinv2(const MatXd& u);
 };
 
 

--- a/src/common/include/bicop_class.hpp
+++ b/src/common/include/bicop_class.hpp
@@ -67,10 +67,6 @@ public:
     VecXd hfunc2(const MatXd& u);
     VecXd hinv1(const MatXd& u);
     VecXd hinv2(const MatXd& u);
-    virtual VecXd hfunc1_default(const MatXd& u) = 0;
-    virtual VecXd hfunc2_default(const MatXd& u) = 0;
-    virtual VecXd hinv1_default(const MatXd& u) = 0;
-    virtual VecXd hinv2_default(const MatXd& u) = 0;
     //! @}
 
     //! Simulate from a bivariate copula
@@ -108,6 +104,11 @@ public:
 
 
 protected:
+    virtual VecXd hfunc1_default(const MatXd& u) = 0;
+    virtual VecXd hfunc2_default(const MatXd& u) = 0;
+    virtual VecXd hinv1_default(const MatXd& u) = 0;
+    virtual VecXd hinv2_default(const MatXd& u) = 0;
+
     //! Numerical inversion of h-functions
     //!
     //! These are generic functions to invert the hfunctions numerically.

--- a/src/common/include/bicop_class.hpp
+++ b/src/common/include/bicop_class.hpp
@@ -78,9 +78,9 @@ public:
     //!
     //! @param u \f$m \times 2\f$ matrix of observations.
     //! @{
-    double loglik(MatXd& u);
-    double aic(MatXd& u);
-    double bic(MatXd& u);
+    double loglik(const MatXd& u);
+    double aic(const MatXd& u);
+    double bic(const MatXd& u);
     //! @}
 
     //! Get number of parameters.

--- a/src/common/include/bicop_class.hpp
+++ b/src/common/include/bicop_class.hpp
@@ -44,7 +44,6 @@ public:
     //! @param u \f$m \times 2\f$ matrix of evaluation points.
     //! @{
     VecXd pdf(const MatXd& u);
-    virtual VecXd pdf_default(const MatXd& u) = 0;
     //! @}
 
     //! \defgroup hfunctions h-functions
@@ -104,6 +103,7 @@ public:
 
 
 protected:
+    virtual VecXd pdf_default(const MatXd& u) = 0;
     virtual VecXd hfunc1_default(const MatXd& u) = 0;
     virtual VecXd hfunc2_default(const MatXd& u) = 0;
     virtual VecXd hinv1_default(const MatXd& u) = 0;

--- a/src/common/include/bicop_class.hpp
+++ b/src/common/include/bicop_class.hpp
@@ -39,10 +39,13 @@ class Bicop
 {
 
 public:
-    //! Copula density
+    //! pdf Copula density
     //!
     //! @param u \f$m \times 2\f$ matrix of evaluation points.
-    virtual VecXd pdf(const MatXd& u) = 0;
+    //! @{
+    VecXd pdf(const MatXd& u);
+    virtual VecXd pdf_default(const MatXd& u) = 0;
+    //! @}
 
     //! \defgroup hfunctions h-functions
     //!
@@ -52,22 +55,23 @@ public:
     //! \f[ h_2(u_1, u_2) = \int_0^{u_1} c(s, u_2) ds. \f]
     //! \c hinv1 is the inverse w.r.t. second argument (conditioned on first),
     //! \c hinv2 is the inverse w.r.t. first argument (conditioned on second),
+    //!
+    //! \c hfunc1, \c hfunc2, \c hinv1, and \c hinv2 mainly take care that
+    //! rotations are properly handled.  They call \c hfunc1_default,
+    //! \c hfunc2_default, \c hinv1_default, and hinv2_default which are
+    //! family-specific implementations for `rotation = 0`.
+    //!
     //! @param u \f$m \times 2\f$ matrix of evaluation points.
     //! @{
-    virtual VecXd hfunc1(const MatXd& u) = 0;
-    virtual VecXd hfunc2(const MatXd& u) = 0;
-    virtual VecXd hinv1(const MatXd& u) = 0;
-    virtual VecXd hinv2(const MatXd& u) = 0;
+    VecXd hfunc1(const MatXd& u);
+    VecXd hfunc2(const MatXd& u);
+    VecXd hinv1(const MatXd& u);
+    VecXd hinv2(const MatXd& u);
+    virtual VecXd hfunc1_default(const MatXd& u) = 0;
+    virtual VecXd hfunc2_default(const MatXd& u) = 0;
+    virtual VecXd hinv1_default(const MatXd& u) = 0;
+    virtual VecXd hinv2_default(const MatXd& u) = 0;
     //! @}
-
-    //! Numerical inversion of h-functions
-    //!
-    //! These are generic functions to invert the hfunctions numerically.
-    //! They can be used in derived classes to define \c hinv1 and \c hinv2.
-    //!
-    //! @param u \f$m \times 2\f$ matrix of evaluation points.
-    VecXd hinv1_num(const MatXd& u);
-    VecXd hinv2_num(const MatXd& u);
 
     //! Simulate from a bivariate copula
     //!
@@ -102,7 +106,23 @@ public:
     void set_parameters(const VecXd& parameters) {parameters_ = parameters;}
     //! @}
 
+
 protected:
+    //! Numerical inversion of h-functions
+    //!
+    //! These are generic functions to invert the hfunctions numerically.
+    //! They can be used in derived classes to define \c hinv1 and \c hinv2.
+    //!
+    //! @param u \f$m \times 2\f$ matrix of evaluation points.
+    VecXd hinv1_num(const MatXd& u);
+    VecXd hinv2_num(const MatXd& u);
+
+    //! Data manipulations for rotated families
+    //!
+    //! @param u \f$m \times 2\f$ matrix of evaluation points.
+    MatXd rotate_u(const MatXd& u);
+    MatXd swap_cols(const MatXd& u);
+
     int family_;
     int rotation_;
     std::string association_direction_;

--- a/src/common/include/bicop_elliptical.hpp
+++ b/src/common/include/bicop_elliptical.hpp
@@ -24,9 +24,14 @@
 
 class EllipticalBicop : public ParBicop  {
 public:
+    // copula density
+    virtual VecXd pdf_default(const MatXd& u) = 0;
+
     // hfunction and its inverse
-    VecXd hfunc2(const MatXd& u);
-    VecXd hinv2(const MatXd& u);
+    virtual VecXd hfunc1_default(const MatXd& u) = 0;
+    VecXd hfunc2_default(const MatXd& u);
+    virtual VecXd hinv1_default(const MatXd& u) = 0;
+    VecXd hinv2_default(const MatXd& u);
 
     // link between Kendall's tau and the par_bicop parameter
     VecXd tau_to_parameters(const double& tau);

--- a/src/common/include/bicop_gauss.hpp
+++ b/src/common/include/bicop_gauss.hpp
@@ -34,13 +34,13 @@ public:
     GaussBicop(const VecXd& parameters, const int& rotation);
 
     // PDF
-    VecXd pdf(const MatXd& u);
+    VecXd pdf_default(const MatXd& u);
 
     // hfunction
-    VecXd hfunc1(const MatXd& u);
+    VecXd hfunc1_default(const MatXd& u);
 
     // inverse hfunction
-    VecXd hinv1(const MatXd& u);
+    VecXd hinv1_default(const MatXd& u);
 };
 
 #endif

--- a/src/common/include/bicop_indep.hpp
+++ b/src/common/include/bicop_indep.hpp
@@ -31,17 +31,16 @@ public:
     IndepBicop(const VecXd& parameters, const int& rotation);
 
     // PDF
-    VecXd pdf(const MatXd& u);
+    VecXd pdf_default(const MatXd& u);
 
     // hfunctions: the conditioning variable is put second
-    VecXd hfunc1(const MatXd& u);
-    VecXd hfunc2(const MatXd& u);
+    VecXd hfunc1_default(const MatXd& u);
+    VecXd hfunc2_default(const MatXd& u);
+    VecXd hinv1_default(const MatXd& u);
+    VecXd hinv2_default(const MatXd& u);
 
     VecXd tau_to_parameters(const double __attribute__((unused))& tau);
     double parameters_to_tau(const VecXd __attribute__((unused))& parameters);
-
-    VecXd hinv1(const MatXd& u);
-    VecXd hinv2(const MatXd& u);
 };
 
 #endif

--- a/src/common/include/bicop_student.hpp
+++ b/src/common/include/bicop_student.hpp
@@ -33,13 +33,13 @@ public:
     StudentBicop(const VecXd& parameters, const int& rotation);
 
     // PDF
-    VecXd pdf(const MatXd& u);
+    VecXd pdf_default(const MatXd& u);
 
     // hfunction
-    VecXd hfunc1(const MatXd& u);
+    VecXd hfunc1_default(const MatXd& u);
 
     // inverse hfunction
-    VecXd hinv1(const MatXd& u);
+    VecXd hinv1_default(const MatXd& u);
 };
 
 

--- a/test/src_test/include/bicop_parametric_test.hpp
+++ b/test/src_test/include/bicop_parametric_test.hpp
@@ -54,10 +54,23 @@ public:
         this->par_bicop_.set_parameters(parameters);
         this->set_family(rinstance_ptr, this->par_bicop_.get_family());
         this->set_parameters(rinstance_ptr, this->par_bicop_.get_parameters());
-    };
+        this->par_bicop_.set_rotation(rinstance_ptr->get_rotation());
+        needs_check_ = true;
+        std::vector<int> rotation_less_fams = {0, 1, 2, 5};
+        bool is_rotless = (
+            std::find(
+                rotation_less_fams.begin(),
+                rotation_less_fams.end(),
+                this->par_bicop_.get_family()
+            )  != rotation_less_fams.end()
+        );
+        if (is_rotless)
+            needs_check_ = (rinstance_ptr->get_rotation() == 0);
+    }
 protected:
     ParBicopTest() : par_bicop_() {}
     T par_bicop_;
+    bool needs_check_;
 };
 
 // Create a list of types, each of which will be used as the test fixture's 'T'

--- a/test/src_test/r_instance.cpp
+++ b/test/src_test/r_instance.cpp
@@ -1,21 +1,21 @@
 /*
-    Copyright 2016 Thibault Vatter
+Copyright 2016 Thibault Vatter
 
-    This file is part of vinecoplib.
+This file is part of vinecoplib.
 
-    vinecoplib is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+vinecoplib is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    vinecoplib is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+vinecoplib is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with vinecoplib.  If not, see <http://www.gnu.org/licenses/>.
- */
+You should have received a copy of the GNU General Public License
+along with vinecoplib.  If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #include "include/r_instance.hpp"
 
@@ -58,25 +58,27 @@ VecXd RInstance::eval_in_R(std::string eval_fct, int start)
 {
 
     std::string new_eval_fct = eval_fct;
-    std::string par = std::to_string(parameters_(0));
     int family = get_family();
+    double parameter = parameters_(0);
 
     // take care of the rotations
-    int rotated_families_array[] = {3,4,6,7,8,9,10};
-    std::vector<int> rotated_families;
-    rotated_families.assign(rotated_families_array,rotated_families_array+7);
-    if(std::find(rotated_families.begin(), rotated_families.end(), family) != rotated_families.end()) {
+    std::vector<int> rotated_families = {3,4,6,7,8,9,10};
+    if (std::find(rotated_families.begin(), rotated_families.end(), family) != rotated_families.end()) {
         int rotation = get_rotation();
-        if (rotation == 180)
-            family += 10;
-        if (rotation == 90)
+        if (rotation == 90) {
             family += 20;
-        if (rotation == 270)
+            parameter *= -1;
+        } else if (rotation == 180) {
+            family += 10;
+        } else if (rotation == 270) {
             family += 30;
+            parameter *= -1;
+        }
     }
 
     // evaluate the function in R
     std::string fam = std::to_string(family);
+    std::string par = std::to_string(parameter);
     new_eval_fct.insert(start,fam);
     new_eval_fct.insert(start+fam.length()+1,par);
     if (parameters_.size() == 1) {

--- a/test/test_bicop_parametric.cpp
+++ b/test/test_bicop_parametric.cpp
@@ -22,7 +22,6 @@
 RInstance *rinstance_ptr = new RInstance;
 
 namespace {
-
     /*TYPED_TEST(ParBicopTest, mle_is_correct) {
         // set-up parameters
         this->setup_parameters(rinstance_ptr);
@@ -42,123 +41,127 @@ namespace {
 
     // Test if the C++ implementation of the par_to_tau and tau_to_par is correct
     TYPED_TEST(ParBicopTest, par_to_tau_is_correct) {
-        // set-up parameters
         this->setup_parameters(rinstance_ptr);
+        if (this->needs_check_) {
+            // evaluate in R
+            MatXd U = this->get_U(rinstance_ptr);
+            std::string eval_fct = "BiCopPar2Tau(,,)";
+            VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 13);
 
-        // evaluate in R
-        MatXd U = this->get_U(rinstance_ptr);
-        std::string eval_fct = "BiCopPar2Tau(,,)";
-        VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 13);
-
-        // assert approximate equality
-        VecXd par = this->get_parameters(rinstance_ptr);
-        ASSERT_TRUE(fabs(this->par_bicop_.parameters_to_tau(par) - f(0)) < 1e-4);
+            // assert approximate equality
+            VecXd par = this->get_parameters(rinstance_ptr);
+            ASSERT_TRUE(fabs(this->par_bicop_.parameters_to_tau(par) - f(0)) < 1e-4);
+        }
     }
 
     // Test if the C++ implementation of the PDF is correct
     TYPED_TEST(ParBicopTest, pdf_is_correct) {
-        // set-up parameters
         this->setup_parameters(rinstance_ptr);
+        if (this->needs_check_) {
+            // evaluate in R
+            MatXd U = this->get_U(rinstance_ptr);
+            std::string eval_fct = "BiCopPDF(u1,u2,,,)";
+            VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 15);
 
-        // evaluate in R
-        MatXd U = this->get_U(rinstance_ptr);
-        std::string eval_fct = "BiCopPDF(u1,u2,,,)";
-        VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 15);
+            // evaluate in C++
+            VecXd f2 = this->par_bicop_.pdf(U);
 
-        // evaluate in C++
-        VecXd f2 = this->par_bicop_.pdf(U);
-
-        // assert approximate equality
-        ASSERT_TRUE(f.isApprox(f2, 1e-4));
+            // assert approximate equality
+            MatXd output(f2.size(), 2);
+            output.col(0) = f;
+            output.col(1) = f2;
+            ASSERT_TRUE(f.isApprox(f2, 1e-4));
+        }
     }
 
     // Test if the C++ implementation of the hfunc1 is correct
     TYPED_TEST(ParBicopTest, hfunc1_is_correct) {
-        // set-up parameters
         this->setup_parameters(rinstance_ptr);
+        if (this->needs_check_) {
+            // evaluate in R
+            MatXd U = this->get_U(rinstance_ptr);
+            std::string eval_fct = "BiCopHfunc1(u1,u2,,,)";
+            VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 18);
 
-        // evaluate in R
-        MatXd U = this->get_U(rinstance_ptr);
-        std::string eval_fct = "BiCopHfunc1(u1,u2,,,)";
-        VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 18);
+            // evaluate in C++
+            VecXd f2 = this->par_bicop_.hfunc1(U);
 
-        // evaluate in C++
-        VecXd f2 = this->par_bicop_.hfunc1(U);
-
-        // assert approximate equality
-        ASSERT_TRUE(f.isApprox(f2, 1e-4));
+            // assert approximate equality
+            ASSERT_TRUE(f.isApprox(f2, 1e-4)) << f(0) << " != " << f2(0);
+        }
     }
 
     // Test if the C++ implementation of the hfunc2 is correct
     TYPED_TEST(ParBicopTest, hfunc2_is_correct) {
-        // set-up parameters
         this->setup_parameters(rinstance_ptr);
+        if (this->needs_check_) {
+            // evaluate in R
+            MatXd U = this->get_U(rinstance_ptr);
+            std::string eval_fct = "BiCopHfunc2(u1,u2,,,)";
+            VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 18);
 
-        // evaluate in R
-        MatXd U = this->get_U(rinstance_ptr);
-        std::string eval_fct = "BiCopHfunc2(u1,u2,,,)";
-        VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 18);
+            // evaluate in C++
+            VecXd f2 = this->par_bicop_.hfunc2(U);
 
-        // evaluate in C++
-        VecXd f2 = this->par_bicop_.hfunc2(U);
-
-        // assert approximate equality
-        ASSERT_TRUE(f.isApprox(f2, 1e-4));
+            // assert approximate equality
+            ASSERT_TRUE(f.isApprox(f2, 1e-4)) << f(0) << " != " << f2(0);
+        }
     }
 
     // Test if the C++ implementation of the hinv1 is correct
     TYPED_TEST(ParBicopTest, hinv1_is_correct) {
-        // set-up parameters
         this->setup_parameters(rinstance_ptr);
+        if (this->needs_check_) {
+            // evaluate in R
+            MatXd U = this->get_U(rinstance_ptr);
+            std::string eval_fct = "BiCopHinv1(u1,u2,,,)";
+            VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 17);
 
-        // evaluate in R
-        MatXd U = this->get_U(rinstance_ptr);
-        std::string eval_fct = "BiCopHinv1(u1,u2,,,)";
-        VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 17);
+            // evaluate in C++
+            VecXd f2 = this->par_bicop_.hinv1(U);
 
-        // evaluate in C++
-        VecXd f2 = this->par_bicop_.hinv1(U);
-
-        // assert approximate equality
-        ASSERT_TRUE(f.isApprox(f2, 1e-4));
+            // assert approximate equality
+            ASSERT_TRUE(f.isApprox(f2, 1e-4));
+        }
     }
 
     // Test if the C++ implementation of the hinv2 is correct
     TYPED_TEST(ParBicopTest, hinv2_is_correct) {
-        // set-up parameters
         this->setup_parameters(rinstance_ptr);
+        if (this->needs_check_) {
+            // evaluate in R
+            MatXd U = this->get_U(rinstance_ptr);
+            std::string eval_fct = "BiCopHinv2(u1,u2,,,)";
+            VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 17);
 
-        // evaluate in R
-        MatXd U = this->get_U(rinstance_ptr);
-        std::string eval_fct = "BiCopHinv2(u1,u2,,,)";
-        VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 17);
+            // evaluate in C++
+            VecXd f2 = this->par_bicop_.hinv2(U);
 
-        // evaluate in C++
-        VecXd f2 = this->par_bicop_.hinv2(U);
-
-        // assert approximate equality
-        ASSERT_TRUE(f.isApprox(f2, 1e-4));
+            // assert approximate equality
+            ASSERT_TRUE(f.isApprox(f2, 1e-4));
+        }
     }
 
     // Test if the C++ implementation of the loglik is correct
     TYPED_TEST(ParBicopTest, loglik_is_correct) {
-        // set-up parameters
         this->setup_parameters(rinstance_ptr);
+        if (this->needs_check_) {
+            // evaluate in R
+            MatXd U = this->get_U(rinstance_ptr);
+            std::string eval_fct = "sum(log(BiCopPDF(u1,u2,,,)))";
+            VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 23);
 
-        // evaluate in R
-        MatXd U = this->get_U(rinstance_ptr);
-        std::string eval_fct = "sum(log(BiCopPDF(u1,u2,,,)))";
-        VecXd f = this->eval_in_R(rinstance_ptr, eval_fct, 23);
+            // evaluate in C++
+            double f2 = this->par_bicop_.loglik(U);
 
-        // evaluate in C++
-        double f2 = this->par_bicop_.loglik(U);
-
-        // assert approximate equality
-        ASSERT_TRUE(fabs(f2 - f(0)) < 1e-2);
+            // assert approximate equality
+            ASSERT_TRUE(fabs(f2 - f(0)) < 1e-2);
+        }
     }
 }
 
 int main(int argc, char **argv) {
+    rinstance_ptr->set_rotation(270);
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
The rotations are now handled at the `Bicop`-level. The implementation at the `Bicop`-level relies on  `pdf_default`, `hfunc1_default`, and so on which constitute the family-specific implementations of the pdf and (inverse) h-functions for the case `rotation_ = 0`.

I'm not too happy with the `_default` suffix, suggestions are welcome ;)