### PR TITLE
Sanity checks

### DIFF
--- a/include/bicop_class.hpp
+++ b/include/bicop_class.hpp
@@ -146,10 +146,6 @@ public:
     void set_parameters(const VecXd& parameters);
     //! @}
     
-    // Check if parameters are in allowed range
-    void check_parameters(const VecXd& parameters);
-    void check_rotation(const int& rotation);
-
 protected:
     virtual VecXd pdf_default(const MatXd& u) = 0;
     virtual VecXd hfunc1_default(const MatXd& u) = 0;
@@ -178,6 +174,13 @@ protected:
     std::string association_direction_;
     VecXd parameters_;
     MatXd parameters_bounds_;   // first column lower, second column upper
+    
+private:
+    //! Sanity checks
+    //! @{
+    void check_parameters(const VecXd& parameters);
+    void check_rotation(const int& rotation);
+    //! @}
 };
 
 typedef std::shared_ptr<Bicop> BicopPtr;

--- a/include/bicop_class.hpp
+++ b/include/bicop_class.hpp
@@ -143,7 +143,7 @@ public:
     MatXd get_parameters_bounds() const {return parameters_bounds_;}
 
     void set_rotation(const int& rotation);
-    void set_parameters(const VecXd& parameters) {parameters_ = parameters;}
+    void set_parameters(const VecXd& parameters);
     //! @}
     
     // Check if parameters are in allowed range

--- a/include/bicop_class.hpp
+++ b/include/bicop_class.hpp
@@ -145,7 +145,9 @@ public:
     void set_rotation(const int& rotation);
     void set_parameters(const VecXd& parameters) {parameters_ = parameters;}
     //! @}
-
+    
+    // Check if parameters are in allowed range
+    void check_parameters(const VecXd& parameters);
 
 protected:
     virtual VecXd pdf_default(const MatXd& u) = 0;
@@ -170,6 +172,7 @@ protected:
     MatXd swap_cols(const MatXd& u);
 
     int family_;
+    std::string family_name_;
     int rotation_;
     std::string association_direction_;
     VecXd parameters_;

--- a/include/bicop_class.hpp
+++ b/include/bicop_class.hpp
@@ -148,6 +148,7 @@ public:
     
     // Check if parameters are in allowed range
     void check_parameters(const VecXd& parameters);
+    void check_rotation(const int& rotation);
 
 protected:
     virtual VecXd pdf_default(const MatXd& u) = 0;

--- a/include/bicop_trafokernel.hpp
+++ b/include/bicop_trafokernel.hpp
@@ -24,6 +24,7 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 
 class TrafokernelBicop : public KernelBicop {
 public:
+    TrafokernelBicop();
     void fit(const MatXd& data, std::string __attribute__((unused)) method);
 };
 

--- a/src/bicop_class.cpp
+++ b/src/bicop_class.cpp
@@ -541,7 +541,24 @@ void Bicop::check_parameters(const VecXd& parameters)
             "actual: " << parameters.size() << std::endl;
         throw std::runtime_error(message.str().c_str());
     }
-
+    if (num_pars > 0) {
+        for (int i = 0; i < num_pars; ++i) {
+            if (parameters(i) < parameters_bounds_(i, 0)) {
+                message << 
+                    "parameters[" << i << "]" <<
+                    " must be larger than " << parameters_bounds_(i, 0) <<
+                    " for the " << family_name_ << " copula" << std::endl;
+                throw std::runtime_error(message.str().c_str());
+            }
+            if (parameters(i) > parameters_bounds_(i, 1)) {
+                message << 
+                "parameters[" << i << "]" <<
+                    " must be smaller than " << parameters_bounds_(i, 1) <<
+                    " for the " << family_name_ << " copula";
+                throw std::runtime_error(message.str().c_str());
+            }
+        }
+    }
 }
 
 template<typename T> bool is_member(T element, std::vector<T> set)

--- a/src/bicop_class.cpp
+++ b/src/bicop_class.cpp
@@ -509,6 +509,7 @@ VecXd Bicop::hinv2_num(const MatXd& u)
 }
 
 void Bicop::set_rotation(const int& rotation) {
+    check_rotation(rotation);    
     rotation_ = rotation;
     if ((this->association_direction_).compare("positive") == 0 ||
             (this->association_direction_).compare("negative") == 0)
@@ -532,9 +533,9 @@ void Bicop::set_parameters(const VecXd& parameters)
 void Bicop::check_parameters(const VecXd& parameters)
 {
     int num_pars = parameters_bounds_.rows();
-    std::stringstream message;
 
     if (parameters.size() != num_pars) {
+        std::stringstream message;
         message << 
             "Wrong size of parameters for " << family_name_ << " copula; " <<
             "expected: " << num_pars << ", " <<
@@ -542,6 +543,7 @@ void Bicop::check_parameters(const VecXd& parameters)
         throw std::runtime_error(message.str().c_str());
     }
     if (num_pars > 0) {
+        std::stringstream message;
         for (int i = 0; i < num_pars; ++i) {
             if (parameters(i) < parameters_bounds_(i, 0)) {
                 message << 
@@ -559,6 +561,16 @@ void Bicop::check_parameters(const VecXd& parameters)
             }
         }
     }
+}
+
+void Bicop::check_rotation(const int& rotation)
+{
+    std::vector<int> allowed_rotations = {0, 90, 180, 270};
+    if (!is_member(rotation, allowed_rotations)) {
+        std::string message = "rotation must be one of {0, 90, 180, 270}";
+        throw std::runtime_error(message);
+    }
+        
 }
 
 template<typename T> bool is_member(T element, std::vector<T> set)

--- a/src/bicop_class.cpp
+++ b/src/bicop_class.cpp
@@ -51,6 +51,7 @@ BicopPtr Bicop::create(const int& family, const int& rotation)
         default:
             throw std::runtime_error(std::string("Family not implemented"));
     }
+    
     my_bicop->set_rotation(rotation);
     return my_bicop;
 }
@@ -520,6 +521,27 @@ void Bicop::set_rotation(const int& rotation) {
             this->association_direction_ = "negative";
         }
     }
+}
+
+void Bicop::set_parameters(const VecXd& parameters)
+{
+    check_parameters(parameters);
+    parameters_ = parameters;
+}
+
+void Bicop::check_parameters(const VecXd& parameters)
+{
+    int num_pars = parameters_bounds_.rows();
+    std::stringstream message;
+
+    if (parameters.size() != num_pars) {
+        message << 
+            "Wrong size of parameters for " << family_name_ << " copula; " <<
+            "expected: " << num_pars << ", " <<
+            "actual: " << parameters.size() << std::endl;
+        throw std::runtime_error(message.str().c_str());
+    }
+
 }
 
 template<typename T> bool is_member(T element, std::vector<T> set)

--- a/src/bicop_clayton.cpp
+++ b/src/bicop_clayton.cpp
@@ -24,6 +24,7 @@
 ClaytonBicop::ClaytonBicop()
 {
     family_ = 3;
+    family_name_ = "Clayton";
     rotation_ = 0;
     association_direction_ = "positive";
     parameters_ = VecXd::Zero(1);
@@ -33,25 +34,15 @@ ClaytonBicop::ClaytonBicop()
 
 ClaytonBicop::ClaytonBicop(const VecXd& parameters)
 {
-    family_ = 3;
-    rotation_ = 0;
-    association_direction_ = "positive";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Zero(1, 2);
-    parameters_bounds_(0, 1) = 200.0;
+    ClaytonBicop();
+    set_parameters(parameters);
 }
 
 ClaytonBicop::ClaytonBicop(const VecXd& parameters, const int& rotation)
 {
-    family_ = 3;
-    rotation_ = rotation;
-    if ((rotation == 90) | (rotation == 270))
-        association_direction_ = "negative";
-    else
-        association_direction_ = "positive";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Zero(1, 2);
-    parameters_bounds_(0, 1) = 200.0;
+    ClaytonBicop();
+    set_parameters(parameters);
+    set_rotation(rotation);
 }
 
 VecXd ClaytonBicop::generator(const VecXd& u)

--- a/src/bicop_frank.cpp
+++ b/src/bicop_frank.cpp
@@ -24,6 +24,7 @@
 FrankBicop::FrankBicop()
 {
     family_ = 5;
+    family_name_ = "Frank";
     rotation_ = 0;
     association_direction_ = "both";
     parameters_ = VecXd::Zero(1);
@@ -34,24 +35,15 @@ FrankBicop::FrankBicop()
 
 FrankBicop::FrankBicop(const VecXd& parameters)
 {
-    family_ = 5;
-    rotation_ = 0;
-    association_direction_ = "both";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Zero(1, 2);
-    parameters_bounds_(0, 0) = -200.0;
-    parameters_bounds_(0, 1) = 200.0;
+    FrankBicop();
+    set_parameters(parameters);
 }
 
 FrankBicop::FrankBicop(const VecXd& parameters, const int& rotation)
 {
-    family_ = 5;
-    rotation_ = rotation;
-    association_direction_ = "both";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Zero(1, 2);
-    parameters_bounds_(0, 0) = -200.0;
-    parameters_bounds_(0, 1) = 200.0;
+    FrankBicop();
+    set_parameters(parameters);
+    set_rotation(rotation);
 }
 
 VecXd FrankBicop::generator(const VecXd& u)

--- a/src/bicop_gauss.cpp
+++ b/src/bicop_gauss.cpp
@@ -23,6 +23,7 @@
 GaussBicop::GaussBicop()
 {
     family_ = 1;
+    family_name_ = "Gaussian";
     rotation_ = 0;
     association_direction_ = "both";
     parameters_ = VecXd::Zero(1);
@@ -32,22 +33,15 @@ GaussBicop::GaussBicop()
 
 GaussBicop::GaussBicop(const VecXd& parameters)
 {
-    family_ = 1;
-    rotation_ = 0;
-    association_direction_ = "both";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Ones(1, 2);
-    parameters_bounds_(0, 0) = -1;
+    GaussBicop();
+    set_parameters(parameters);
 }
 
 GaussBicop::GaussBicop(const VecXd& parameters, const int& rotation)
 {
-    family_ = 1;
-    rotation_ = rotation;
-    association_direction_ = "both";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Ones(1, 2);
-    parameters_bounds_(0, 0) = -1;
+    GaussBicop();
+    set_parameters(parameters);
+    set_rotation(rotation);
 }
 
 // PDF

--- a/src/bicop_gumbel.cpp
+++ b/src/bicop_gumbel.cpp
@@ -24,6 +24,7 @@
 GumbelBicop::GumbelBicop()
 {
     family_ = 4;
+    family_name_ = "Gumbel";
     rotation_ = 0;
     association_direction_ = "positive";
     parameters_ = VecXd::Ones(1);
@@ -33,25 +34,15 @@ GumbelBicop::GumbelBicop()
 
 GumbelBicop::GumbelBicop(const VecXd& parameters)
 {
-    family_ = 4;
-    rotation_ = 0;
-    association_direction_ = "positive";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Ones(1, 2);
-    parameters_bounds_(0, 1) = 200.0;
+    GumbelBicop();
+    set_parameters(parameters);
 }
 
 GumbelBicop::GumbelBicop(const VecXd& parameters, const int& rotation)
 {
-    family_ = 4;
-    rotation_ = rotation;
-    if ((rotation == 90) | (rotation == 270))
-        association_direction_ = "negative";
-    else
-        association_direction_ = "positive";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Ones(1, 2);
-    parameters_bounds_(0, 1) = 200.0;
+    GumbelBicop();
+    set_parameters(parameters);
+    set_rotation(rotation);
 }
 
 VecXd GumbelBicop::generator(const VecXd& u)

--- a/src/bicop_indep.cpp
+++ b/src/bicop_indep.cpp
@@ -28,7 +28,7 @@ IndepBicop::IndepBicop()
     association_direction_ = "none";
 }
 
-IndepBicop::IndepBicop(const VecXd & parameters)
+IndepBicop::IndepBicop(const VecXd& parameters)
 {
     IndepBicop();
     set_parameters(parameters);
@@ -70,7 +70,8 @@ VecXd IndepBicop::hinv2_default(const MatXd& u)
 
 VecXd IndepBicop::tau_to_parameters(const double __attribute__((unused))& tau)
 {
-    return VecXd::Zero(1);
+    VecXd pars;
+    return pars;
 }
 
 double IndepBicop::parameters_to_tau(const VecXd __attribute__((unused))& parameters)

--- a/src/bicop_indep.cpp
+++ b/src/bicop_indep.cpp
@@ -23,28 +23,22 @@
 IndepBicop::IndepBicop()
 {
     family_ = 0;
+    family_name_ = "Independence";
     rotation_ = 0;
     association_direction_ = "none";
-    parameters_ = VecXd::Zero(1);
-    parameters_bounds_ = MatXd::Zero(1, 2);
 }
 
 IndepBicop::IndepBicop(const VecXd & parameters)
 {
-    family_ = 0;
-    rotation_ = 0;
-    association_direction_ = "none";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Zero(1, 2);
+    IndepBicop();
+    set_parameters(parameters);
 }
 
 IndepBicop::IndepBicop(const VecXd& parameters, const int& rotation)
 {
-    family_ = 0;
-    rotation_ = rotation;
-    association_direction_ = "none";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Zero(1, 2);
+    IndepBicop();
+    set_parameters(parameters);
+    set_rotation(rotation);
 }
 
 // PDF

--- a/src/bicop_joe.cpp
+++ b/src/bicop_joe.cpp
@@ -24,6 +24,7 @@
 JoeBicop::JoeBicop()
 {
     family_ = 6;
+    family_name_ = "Joe";
     rotation_ = 0;
     association_direction_ = "positive";
     parameters_ = VecXd::Ones(1);
@@ -33,25 +34,15 @@ JoeBicop::JoeBicop()
 
 JoeBicop::JoeBicop(const VecXd& parameters)
 {
-    family_ = 6;
-    rotation_ = 0;
-    association_direction_ = "positive";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Ones(1, 2);
-    parameters_bounds_(0, 1) = 200.0;
+    JoeBicop();
+    set_parameters(parameters);
 }
 
 JoeBicop::JoeBicop(const VecXd& parameters, const int& rotation)
 {
-    family_ = 6;
-    rotation_ = rotation;
-    if ((rotation == 90) | (rotation == 270))
-        association_direction_ = "negative";
-    else
-        association_direction_ = "positive";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Ones(1, 2);
-    parameters_bounds_(0, 1) = 200.0;
+    JoeBicop();
+    set_parameters(parameters);
+    set_rotation(rotation);
 }
 
 VecXd JoeBicop::generator(const VecXd& u)

--- a/src/bicop_student.cpp
+++ b/src/bicop_student.cpp
@@ -23,6 +23,7 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 StudentBicop::StudentBicop()
 {
     family_ = 2;
+    family_name_ = "t";
     rotation_ = 0;
     association_direction_ = "both";
     parameters_ = VecXd::Zero(2);
@@ -35,26 +36,15 @@ StudentBicop::StudentBicop()
 
 StudentBicop::StudentBicop(const VecXd& parameters)
 {
-    family_ = 2;
-    rotation_ = 0;
-    association_direction_ = "both";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Ones(2, 2);
-    parameters_bounds_(0, 0) = -1.0;
-    parameters_bounds_(1, 0) = 2.0;
-    parameters_bounds_(1, 1) = 50.0;
+    StudentBicop();
+    set_parameters(parameters);
 }
 
 StudentBicop::StudentBicop(const VecXd& parameters, const int& rotation)
 {
-    family_ = 2;
-    rotation_ = rotation;
-    association_direction_ = "both";
-    parameters_ = parameters;
-    parameters_bounds_ = MatXd::Ones(2, 2);
-    parameters_bounds_(0, 0) = -1.0;
-    parameters_bounds_(1, 0) = 2.0;
-    parameters_bounds_(1, 1) = 50.0;
+    StudentBicop();
+    set_parameters(parameters);
+    set_rotation(rotation);
 }
 
 // PDF

--- a/src/bicop_student.cpp
+++ b/src/bicop_student.cpp
@@ -27,7 +27,7 @@ StudentBicop::StudentBicop()
     rotation_ = 0;
     association_direction_ = "both";
     parameters_ = VecXd::Zero(2);
-    parameters_(1) = 100.0;
+    parameters_(1) = 50.0;
     parameters_bounds_ = MatXd::Ones(2, 2);
     parameters_bounds_(0, 0) = -1.0;
     parameters_bounds_(1, 0) = 2.0;

--- a/src/bicop_trafokernel.cpp
+++ b/src/bicop_trafokernel.cpp
@@ -20,6 +20,13 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 #include "bicop_trafokernel.hpp"
 #include "bicop.hpp"
 
+TrafokernelBicop::TrafokernelBicop()
+{
+    family_ = 1001;
+    rotation_ = 0;
+    association_direction_ = "both";
+}
+
 VecXd gaussian_kernel_2d(const MatXd& x)
 {
     return x.unaryExpr(std::ptr_fun(gsl_ran_ugaussian_pdf)).rowwise().prod();

--- a/src/bicop_trafokernel.cpp
+++ b/src/bicop_trafokernel.cpp
@@ -23,6 +23,7 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 TrafokernelBicop::TrafokernelBicop()
 {
     family_ = 1001;
+    family_name_ = "Transformation kernel";
     rotation_ = 0;
     association_direction_ = "both";
 }

--- a/test/src_test/include/bicop_parametric_test.hpp
+++ b/test/src_test/include/bicop_parametric_test.hpp
@@ -53,7 +53,7 @@ public:
 
         // set the rotion and compute the parameters vector
         this->par_bicop_.set_rotation(rinstance_ptr->get_rotation());
-        VecXd parameters(2);
+        VecXd parameters;
         parameters = this->par_bicop_.tau_to_parameters(tau);
         if (parameters.size() == 2)
             parameters(1) = 4.0;

--- a/test/test_bicop_class.cpp
+++ b/test/test_bicop_class.cpp
@@ -23,15 +23,13 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 namespace {
     // Test if the C++ implementation of the par_to_tau and tau_to_par is correct
     TEST(bicop_class, creates_right_copula) {
-        BicopPtr bicop;
-        bicop = Bicop::create(1, VecXd::Zero(1), 90);
+        BicopPtr bicop = Bicop::create(1, VecXd::Ones(1), 90);
         EXPECT_EQ(bicop->get_family(), 1);
         EXPECT_EQ(bicop->get_rotation(), 90);
-        EXPECT_EQ(bicop->get_parameters(), VecXd::Zero(1));
+        EXPECT_EQ(bicop->get_parameters(), VecXd::Ones(1));
     }
     
     TEST(bicop_class, catches_wrong_parameter_size) {
-        BicopPtr bicop;
         EXPECT_ANY_THROW(Bicop::create(0, VecXd::Zero(1), 0));
         EXPECT_ANY_THROW(Bicop::create(1, VecXd::Zero(0), 0));
         EXPECT_ANY_THROW(Bicop::create(2, VecXd::Zero(1), 0));
@@ -40,6 +38,16 @@ namespace {
         EXPECT_ANY_THROW(Bicop::create(5, VecXd::Zero(2), 0));
         EXPECT_ANY_THROW(Bicop::create(6, VecXd::Zero(0), 0));
         EXPECT_ANY_THROW(Bicop::create(1001, VecXd::Zero(1), 0));
+    }
+    
+    TEST(bicop_class, catches_parameters_out_of_bounds) {
+        EXPECT_ANY_THROW(Bicop::create(1, VecXd::Constant(1, -1.1), 0));
+        EXPECT_ANY_THROW(Bicop::create(2, VecXd::Zero(2), 0));
+        EXPECT_ANY_THROW(Bicop::create(2, VecXd::Constant(2, 4.0), 0));
+        EXPECT_ANY_THROW(Bicop::create(3, VecXd::Constant(1, -0.1), 0));
+        EXPECT_ANY_THROW(Bicop::create(4, VecXd::Constant(1, 1000.0), 0));
+        EXPECT_ANY_THROW(Bicop::create(5, VecXd::Constant(1, 10000.0), 0));
+        EXPECT_ANY_THROW(Bicop::create(6, VecXd::Constant(1, -0.1), 0));
     }
 }
 

--- a/test/test_bicop_class.cpp
+++ b/test/test_bicop_class.cpp
@@ -23,21 +23,16 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 namespace {
     // Test if the C++ implementation of the par_to_tau and tau_to_par is correct
     TEST(bicop_class, creates_right_copula) {
-        std::vector<int> fams = {0, 1, 2, 3, 4, 5, 6};
-        std::vector<int> rots = {0, 90, 180, 270};
-
-        for (unsigned int i = 0; i < fams.size(); ++i) {
-            for (unsigned int j = 0; j < rots.size(); ++j) {
-                BicopPtr bicop = Bicop::create(fams[i], VecXd::Zero(1), rots[j]);
-                EXPECT_EQ(bicop->get_family(), fams[i]);
-                EXPECT_EQ(bicop->get_rotation(), rots[j]);
-                EXPECT_EQ(bicop->get_parameters(), VecXd::Zero(1));
-            }
-        }
+        BicopPtr bicop;
+        bicop = Bicop::create(1, VecXd::Zero(1), 90);
+        EXPECT_EQ(bicop->get_family(), 1);
+        EXPECT_EQ(bicop->get_rotation(), 90);
+        EXPECT_EQ(bicop->get_parameters(), VecXd::Zero(1));
     }
     
     TEST(bicop_class, check_for_parameters_bounds) {
-        BicopPtr bicop = Bicop::create(3, VecXd::Zero(1), 0);
+        BicopPtr bicop;
+        bicop = Bicop::create(3, VecXd::Zero(1), 0);
     }
 }
 

--- a/test/test_bicop_class.cpp
+++ b/test/test_bicop_class.cpp
@@ -22,7 +22,7 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace {
     // Test if the C++ implementation of the par_to_tau and tau_to_par is correct
-    TEST(ParBicopTest, bicop_creates_right_copula) {
+    TEST(bicop_class, creates_right_copula) {
         std::vector<int> fams = {0, 1, 2, 3, 4, 5, 6};
         std::vector<int> rots = {0, 90, 180, 270};
 
@@ -34,6 +34,10 @@ namespace {
                 EXPECT_EQ(bicop->get_parameters(), VecXd::Zero(1));
             }
         }
+    }
+    
+    TEST(bicop_class, check_for_parameters_bounds) {
+        BicopPtr bicop = Bicop::create(3, VecXd::Zero(1), 0);
     }
 }
 

--- a/test/test_bicop_class.cpp
+++ b/test/test_bicop_class.cpp
@@ -30,9 +30,16 @@ namespace {
         EXPECT_EQ(bicop->get_parameters(), VecXd::Zero(1));
     }
     
-    TEST(bicop_class, check_for_parameters_bounds) {
+    TEST(bicop_class, catches_wrong_parameter_size) {
         BicopPtr bicop;
-        bicop = Bicop::create(3, VecXd::Zero(1), 0);
+        EXPECT_ANY_THROW(Bicop::create(0, VecXd::Zero(1), 0));
+        EXPECT_ANY_THROW(Bicop::create(1, VecXd::Zero(0), 0));
+        EXPECT_ANY_THROW(Bicop::create(2, VecXd::Zero(1), 0));
+        EXPECT_ANY_THROW(Bicop::create(3, VecXd::Zero(2), 0));
+        EXPECT_ANY_THROW(Bicop::create(4, VecXd::Zero(0), 0));
+        EXPECT_ANY_THROW(Bicop::create(5, VecXd::Zero(2), 0));
+        EXPECT_ANY_THROW(Bicop::create(6, VecXd::Zero(0), 0));
+        EXPECT_ANY_THROW(Bicop::create(1001, VecXd::Zero(1), 0));
     }
 }
 

--- a/test/test_bicop_class.cpp
+++ b/test/test_bicop_class.cpp
@@ -49,6 +49,11 @@ namespace {
         EXPECT_ANY_THROW(Bicop::create(5, VecXd::Constant(1, 10000.0), 0));
         EXPECT_ANY_THROW(Bicop::create(6, VecXd::Constant(1, -0.1), 0));
     }
+    
+    TEST(bicop_class, catches_wrong_rotation) {
+        EXPECT_ANY_THROW(Bicop::create(1, VecXd::Zero(1), -10));
+        EXPECT_ANY_THROW(Bicop::create(1, VecXd::Zero(1), 10));
+    }
 }
 
 int main(int argc, char **argv) {

--- a/test/test_bicop_trafokernel.cpp
+++ b/test/test_bicop_trafokernel.cpp
@@ -24,7 +24,7 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 namespace {
     // Test if the C++ implementation of the par_to_tau and tau_to_par is correct
     TEST(KernelBicopTest, trafo_kernel_fit_works) {
-        BicopPtr cop = Bicop::create(1001, VecXd::Zero(1), 0);
+        BicopPtr cop = Bicop::create(1001, 0);
         MatXd dat = MatXd::Random(100, 2).array() * 0.5 + 0.5;
         MatXd eval = MatXd::Random(10, 2).array() * 0.5 + 0.5;
         cop->fit(dat, std::string(""));


### PR DESCRIPTION
I wrote some basic sanity checks:
   - do parameters have the correct size?
   - are the parameters within bounds?
   - is the rotation valid?

There are a couple of more changes I made along the way:
   - new `family_name_`data member in `Bicop`, used for error messages.
   - simplified the parameterized constructors of the family classes by calling the default constructor.
   - use an empty parameter vector for the Independence copula.