### PR TITLE
Vine matrix utilities refactored

### DIFF
--- a/include/rvine_matrix.hpp
+++ b/include/rvine_matrix.hpp
@@ -34,29 +34,21 @@ public:
     RVineMatrix(const MatXi& matrix);
     //! @}
     
-    //! \devgroup getters Getters
+    //! Getters
     //! @{
     MatXi get_matrix();
-    MatXi get_no_matrix();
+    //! @}
+    
+    MatXi in_natural_order();
     MatXi get_max_matrix();
     MatXb get_needed_hfunc1();
     MatXb get_needed_hfunc2();
-    //! @}
 
     static MatXi construct_d_vine_matrix(const VecXd& order);
 
 private:
-    MatXi to_natural_order(const MatXi& matrix);
-    MatXi to_max_matrix(const MatXi& no_matrix);
-    MatXb compute_needed_hfunc1(const MatXi& no_matrix) ;
-    MatXb compute_needed_hfunc2(const MatXi& no_matrix) ;
-
     int d_;
     MatXi matrix_;
-    MatXi no_matrix_;
-    MatXi max_matrix_;
-    MatXb needed_hfunc1_;
-    MatXb needed_hfunc2_;
 };
 
 int relabel_one(const int& x, const VecXi& old_labels, const VecXi& new_labels);

--- a/include/rvine_matrix.hpp
+++ b/include/rvine_matrix.hpp
@@ -44,7 +44,7 @@ public:
     MatXb get_needed_hfunc1();
     MatXb get_needed_hfunc2();
 
-    static MatXi construct_d_vine_matrix(const VecXd& order);
+    static MatXi construct_d_vine_matrix(const VecXi& order);
 
 private:
     int d_;

--- a/src/rvine_matrix.cpp
+++ b/src/rvine_matrix.cpp
@@ -38,23 +38,24 @@ MatXi RVineMatrix::get_matrix()
 //! @param order order of the variables
 //! 
 //! @return An Eigen::MatrixXi describing the D-vine structure.
-MatXi RVineMatrix::construct_d_vine_matrix(const VecXd& order)
+MatXi RVineMatrix::construct_d_vine_matrix(const VecXi& order)
 {
     int d = order.size();
-    MatXi vine_matrix(d, d);
+    MatXi vine_matrix = MatXi::Constant(d, d, 0);
     
     for (int i = 0; i < d; ++i) {
-        vine_matrix(d - i, d - i) = order(i);
+        vine_matrix(i, i) = order(d - 1 - i);  // diagonal
     }
     
-    for (int i = 0; i < d; ++i) {
-        for (int j = 1; j < d - 1; ++j) {
-            vine_matrix(d - i, d - j - i) = order(j);
+    for (int i = 1; i < d; ++i) {
+        for (int j = 0; j < i; ++j) {
+            vine_matrix(i, j) = order(i - j - 1);  // below diagonal
         }
     }
-    
+
     return vine_matrix;
 }
+
 
 //! Reorder R-vine matrix to natural order 
 //! 

--- a/src/vinecop_class.cpp
+++ b/src/vinecop_class.cpp
@@ -31,7 +31,7 @@ Vinecop::Vinecop(const int& d)
     d_ = d;
     
     // D-vine with variable order (1, ..., d)
-    VecXd order(d);
+    VecXi order(d);
     for (int i = 0; i < d; ++i)
         order(i) = i + 1;
     RVineMatrix vine_matrix_(RVineMatrix::construct_d_vine_matrix(order));

--- a/test/test_rvine_matrix.cpp
+++ b/test/test_rvine_matrix.cpp
@@ -40,7 +40,7 @@ namespace {
                           2, 3, 1, 1, 1, 1, 1;
                           
         RVineMatrix rvine_matrix(mat);
-        EXPECT_EQ(rvine_matrix.get_no_matrix(), true_no_matrix);
+        EXPECT_EQ(rvine_matrix.in_natural_order(), true_no_matrix);
     }
     
     TEST(rvine_matrix, max_mat_is_correct) {

--- a/test/test_rvine_matrix.cpp
+++ b/test/test_rvine_matrix.cpp
@@ -108,6 +108,20 @@ namespace {
         RVineMatrix rvine_matrix(mat);
         EXPECT_EQ(rvine_matrix.get_needed_hfunc2(), true_hfunc2);
     }
+    
+    TEST(rvine_matrix, construct_d_vine_matrix_is_correct) {
+        VecXi order(7);
+        order << 7, 2, 3, 5, 1, 4, 6;
+        MatXi true_d_vine_matrix(7, 7);
+        true_d_vine_matrix << 6, 0, 0, 0, 0, 0, 0,
+                              7, 4, 0, 0, 0, 0, 0,
+                              2, 7, 1, 0, 0, 0, 0,
+                              3, 2, 7, 5, 0, 0, 0,
+                              5, 3, 2, 7, 3, 0, 0,
+                              1, 5, 3, 2, 7, 2, 0,
+                              4, 1, 5, 3, 2, 7, 7;
+        EXPECT_EQ(RVineMatrix::construct_d_vine_matrix(order), true_d_vine_matrix);
+     }
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
I did what was suggested in #17. The getters now compute the matrices directly. This adds a little overhead, but should be ok. They are only called once when evaluating pdf or simulating.

Also corrected `construct_d_vine_matrix` and added a test for it.