### PR TITLE
Hinv speedup

### DIFF
--- a/include/bicop_class.hpp
+++ b/include/bicop_class.hpp
@@ -29,6 +29,7 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 #include <exception>
 #include <cmath>
+#include <functional>
 
 typedef Eigen::VectorXd VecXd;
 typedef Eigen::MatrixXd MatXd;
@@ -187,5 +188,6 @@ double correlation(const MatXd& z);
 template<typename T> bool is_member(T element, std::vector<T> set);
 std::vector<double> get_c1c2(const MatXd& data, double tau);
 bool preselect_family(double c1, double c2, double tau, int family, int rotation, bool is_rotationless);
+VecXd invert_f(const VecXd &x, std::function<VecXd(const VecXd&)> f, int n_iter = 35);
 
 #endif

--- a/src/bicop_class.cpp
+++ b/src/bicop_class.cpp
@@ -411,9 +411,9 @@ VecXd Bicop::hinv1_num(const MatXd &u)
     VecXd xl = VecXd::Constant(u1.size(), 1e-20);
     VecXd xh = 1.0 - xl.array();
 
-    v.col(1) = xl * VecXd::Ones(u1.size());
+    v.col(1) = xl;
     VecXd fl = (hfunc1(v) - u1).cwiseAbs();
-    v.col(1) = xh * VecXd::Ones(u1.size());
+    v.col(1) = xh;
     VecXd fh = (hfunc1(v) - u1).cwiseAbs();
     VecXd fm = VecXd::Ones(u1.size());
     
@@ -437,9 +437,9 @@ VecXd Bicop::hinv2_num(const MatXd& u)
     VecXd xl = VecXd::Constant(u1.size(), 1e-20);
     VecXd xh = 1.0 - xl.array();
     
-    v.col(0) = xl * VecXd::Ones(u1.size());
+    v.col(0) = xl;
     VecXd fl = (hfunc2(v) - u1).cwiseAbs();
-    v.col(0) = xh * VecXd::Ones(u1.size());
+    v.col(0) = xh;
     VecXd fh = (hfunc2(v) - u1).cwiseAbs();
     VecXd fm = VecXd::Ones(u1.size());
 

--- a/src/bicop_class.cpp
+++ b/src/bicop_class.cpp
@@ -567,17 +567,15 @@ bool preselect_family(double c1, double c2, double tau, int family, int rotation
     return preselect;
 }
 
-//! Numerical inversion of a univariate function
+//! Numerical inversion of a function on [0, 1].
 //! 
 //! Computes the inverse \f$f^{-1}\f$ of a function \f$f\f$ by the bisection 
 //! method.
 //! 
 //! @param x evaluation points.
 //! @param f the function to invert.
-//! @param n_iter the number of iterations for the bisection. 
-//! 
-//! The default are 35 iterations which guarantee an accuracy of 
-//! 0.5^35 ~= 6e-11 if the domain is the unit interval.
+//! @param n_iter the number of iterations for the bisection (defaults to 35,
+//! guaranteeing an accuracy of 0.5^35 ~= 6e-11). 
 //! 
 //! @return f^{-1}(x).
 VecXd invert_f(const VecXd &x, std::function<VecXd(const VecXd&)> f, int n_iter) 

--- a/src/bicop_class.cpp
+++ b/src/bicop_class.cpp
@@ -416,7 +416,7 @@ VecXd Bicop::hinv2_num(const MatXd &u)
     MatXd u_new = u;
     auto h1 = [&](const VecXd &x) {
         u_new.col(0) = x; 
-        return hfunc1_default(u_new);
+        return hfunc2_default(u_new);
     };
     
     return invert_f(u.col(0), h1);


### PR DESCRIPTION
It really annoyed me that our numerical inversion for the h-function was so slow. It only affected the Frank copula so far, but we will probably use it for most family that we add in the future. I did some informal profiling and noticed a substantial overhead from calling the vectorized function `hfuncX_default` on a single point. 

So I implemented a vectorized version of the bisection method that always runs through 35 iterations for all evaluation points. This guarantees an accuracy of more than  `1e-10` on each evaluation. The code is shorter, more elegant, and runs much faster:

Timings on my computer for evaluating Frank's `hinv1` on `1e4` points:
- VineCopula: 85ms
- vinecopulib (old): 260ms
- vinecopulib (new): 37ms