### PR TITLE
moving away the dependence on nlopt.hpp from user-exposed header

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,12 +29,12 @@ build_script:
   - cd build-debug
   - cmake .. %CMAKE_ARGS% -DCMAKE_BUILD_TYPE=Debug
   - cmake --build .
-  - ctest --output-on-failure 
+  - ctest -C Debug --output-on-failure 
   - cd ..
 
   - md build-release
   - cd build-release
   - cmake .. %CMAKE_ARGS% -DCMAKE_BUILD_TYPE=Release
   - cmake --build .
-  - ctest --output-on-failure 
+  - ctest -C Release --output-on-failure 
   - cd ..

--- a/include/bicop_class.hpp
+++ b/include/bicop_class.hpp
@@ -22,7 +22,6 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "boost_tools.hpp"
 #include <Eigen/Dense>
-#include <nlopt.hpp>
 #include <random>
 #include <iostream>
 #include <memory>

--- a/src/bicop_parametric.cpp
+++ b/src/bicop_parametric.cpp
@@ -17,6 +17,7 @@
     along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <nlopt.hpp>
 #include "bicop_parametric.hpp"
 
 // calculate number of parameters


### PR DESCRIPTION
Addresses: https://github.com/tvatter/vinecopulib/issues/39