### PR TITLE
fix bugs in trafo kernel flip and select

### DIFF
--- a/include/interpolation_grid.hpp
+++ b/include/interpolation_grid.hpp
@@ -20,7 +20,6 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef VINECOPULIB_BICOP_INTERPOLATION_HPP
 #define VINECOPULIB_BICOP_INTERPOLATION_HPP
 
-#include <exception>
 #include <Eigen/Dense>
 
 typedef Eigen::VectorXd VecXd;

--- a/src/bicop_class.cpp
+++ b/src/bicop_class.cpp
@@ -163,7 +163,7 @@ BicopPtr Bicop::select(const MatXd& data,
         // Estimate the model
         BicopPtr new_bicop = create(families[j], rotations[j]);
         new_bicop->fit(newdata, method);
-
+    
         // Compute the selection criterion
         double new_criterion;
         if (selection_criterion.compare("aic") == 0)
@@ -176,7 +176,7 @@ BicopPtr Bicop::select(const MatXd& data,
         {
             throw std::runtime_error(std::string("Selection criterion not implemented"));
         }
-
+            
         // If the new model is better than the current one, then replace the current model by the new one
         if (new_criterion < fitted_criterion)
         {
@@ -501,7 +501,7 @@ bool preselect_family(double c1, double c2, double tau, int family, int rotation
     {
         if (std::fabs(c1-c2) > 0.3)
         {
-            if (family == 2 || family == 0)
+            if (family == 2 || family == 0 || family == 1001)
             {
                 preselect = true;
             }

--- a/src/interpolation_grid.cpp
+++ b/src/interpolation_grid.cpp
@@ -18,7 +18,11 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "interpolation_grid.hpp"
+#include "distribution_tools.hpp"
+#include <exception>
+
 // ---------------- Public methods ----------------
+
 
 //! Constructor
 //!
@@ -45,9 +49,8 @@ InterpolationGrid::InterpolationGrid(const VecXd& grid_points, const MatXd& valu
 
 void InterpolationGrid::flip()
 {
-    values_ = values_.transpose();
+    values_.transposeInPlace();
 }
-
 
 //! Interpolation in two dimensions
 //!

--- a/test/test_bicop_trafokernel.cpp
+++ b/test/test_bicop_trafokernel.cpp
@@ -22,28 +22,50 @@ along with vinecopulib.  If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 
 namespace {
-    // Test if the C++ implementation of the par_to_tau and tau_to_par is correct
-    TEST(KernelBicopTest, trafo_kernel_fit_works) {
-        BicopPtr cop = Bicop::create(1001, 0);
-        MatXd dat = MatXd::Random(100, 2).array() * 0.5 + 0.5;
-        MatXd eval = MatXd::Random(10, 2).array() * 0.5 + 0.5;
-        cop->fit(dat, std::string(""));
-        
-        EXPECT_GE(cop->pdf(eval).minCoeff(), 0.0);
-        
-        EXPECT_GE(cop->hfunc1(eval).minCoeff(), 0.0);
-        EXPECT_GE(cop->hfunc2(eval).minCoeff(), 0.0);
-        EXPECT_GE(cop->hinv1(eval).minCoeff(), 0.0);
-        EXPECT_GE(cop->hinv2(eval).minCoeff(), 0.0);
-        
-        EXPECT_LE(cop->hfunc1(eval).maxCoeff(), 1.0);
-        EXPECT_LE(cop->hfunc2(eval).maxCoeff(), 1.0);
-        EXPECT_LE(cop->hinv1(eval).maxCoeff(), 1.0);
-        EXPECT_LE(cop->hinv2(eval).maxCoeff(), 1.0);
+    
+    TEST(KernelBicopTest, trafo_kernel_fit) {
+        auto cop = Bicop::create(1001, 0);
+        auto u = simulate_uniform(100, 2);
+        cop->fit(u, std::string(""));
+    }
+    
+    TEST(KernelBicop, trafo_kernel_eval_funcs) {
+        auto cop = Bicop::create(1001, 0);
+        auto u = simulate_uniform(100, 2);
+        cop->fit(u, std::string(""));
 
+        EXPECT_GE(cop->pdf(u).minCoeff(), 0.0);
+        
+        EXPECT_GE(cop->hfunc1(u).minCoeff(), 0.0);
+        EXPECT_GE(cop->hfunc2(u).minCoeff(), 0.0);
+        EXPECT_GE(cop->hinv1(u).minCoeff(), 0.0);
+        EXPECT_GE(cop->hinv2(u).minCoeff(), 0.0);
+        
+        EXPECT_LE(cop->hfunc1(u).maxCoeff(), 1.0);
+        EXPECT_LE(cop->hfunc2(u).maxCoeff(), 1.0);
+        EXPECT_LE(cop->hinv1(u).maxCoeff(), 1.0);
+        EXPECT_LE(cop->hinv2(u).maxCoeff(), 1.0);
+        
         EXPECT_GE(cop->calculate_npars(), 0.0);
         EXPECT_LE(cop->calculate_npars(), 100.0);
+    } 
+    
+    TEST(KernelBicoptest, trafo_kernel_select) {
+        auto u = simulate_uniform(100, 2);
+        auto cop = Bicop::select(u, "bic", {1001}, true, true, "mle");
+        EXPECT_EQ(cop->get_family(), 1001);
     }
+
+    TEST(KernelBicoptest, trafo_kernel_flip) {
+        auto u = simulate_uniform(100, 2);
+        auto cop = Bicop::select(u, "bic", {1001}, true, true, "mle");
+        auto pdf = cop->pdf(u);
+        u.col(0).swap(u.col(1));
+        cop->flip();
+        auto pdf_flipped = cop->pdf(u);
+        EXPECT_TRUE(pdf.isApprox(pdf_flipped, 1e-10));
+    }
+    
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
* flip caused ASAN errors (transposeInPlace must be used)
* preselect_families did not handle the family properly