### PR TITLE
using find_package(Threads) instead of set(external_libs "-lpthread")

### DIFF
--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -3,7 +3,8 @@
 #set(Boost_USE_STATIC_RUNTIME OFF)
 
 find_package(Boost 1.63 REQUIRED)
+find_package(Threads REQUIRED)
 
 set(external_includes ${EIGEN3_INCLUDE_DIR} ${NLOPT_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
 
-set(external_libs "-lpthread" ${NLOPT_LIBRARIES} ${Boost_LIBRARIES})
+set(external_libs ${CMAKE_THREAD_LIBS_INIT} ${NLOPT_LIBRARIES} ${Boost_LIBRARIES})


### PR DESCRIPTION
will hopefully silence tons of warning on Appveyor